### PR TITLE
Use shared payload types in services

### DIFF
--- a/apps/services/api-gateway/src/auth/auth.service.ts
+++ b/apps/services/api-gateway/src/auth/auth.service.ts
@@ -3,8 +3,7 @@ import { ClientProxy } from '@nestjs/microservices'
 import { firstValueFrom } from 'rxjs'
 import { AuthResult, UserResult, ValidateTokenResult } from '@dailyshop/shared-types'
 import { AppLogger } from '@dailyshop/shared-utils'
-import { LoginHttpDto } from './dto/login-http.dto'
-import { RegisterHttpDto } from './dto/register-http.dto'
+import { LoginPayload, RegisterPayload } from '@dailyshop/shared-types'
 
 @Injectable()
 export class AuthService {
@@ -14,7 +13,7 @@ export class AuthService {
     private readonly logger: AppLogger
   ) {}
 
-  async register(dto: RegisterHttpDto) {
+  async register(dto: RegisterPayload): Promise<UserResult> {
     this.logger.log(`Register payload: ${JSON.stringify(dto)}`)
     const authResult = await firstValueFrom<AuthResult>(this.authClient.send({ cmd: 'auth-register' }, dto))
     this.logger.log(`Auth service result: ${JSON.stringify(authResult)}`)
@@ -25,14 +24,14 @@ export class AuthService {
     return userResult
   }
 
-  async login(dto: LoginHttpDto) {
+  async login(dto: LoginPayload): Promise<{ token: string }> {
     this.logger.log(`Login attempt for ${dto.email}`)
     const result = await firstValueFrom<{ token: string }>(this.authClient.send({ cmd: 'auth-login' }, dto))
     this.logger.log('Login token issued')
     return result
   }
 
-  async validateToken(token: string) {
+  async validateToken(token: string): Promise<ValidateTokenResult | null> {
     this.logger.log('Validating token')
     const result = await firstValueFrom<ValidateTokenResult | null>(
       this.authClient.send({ cmd: 'auth-validate-token' }, token)

--- a/apps/services/api-gateway/src/product/product.controller.ts
+++ b/apps/services/api-gateway/src/product/product.controller.ts
@@ -19,16 +19,16 @@ export class ProductController {
 
   @Get(':id')
   findOne(@Param('id') id: string) {
-    return this.productService.findOne(+id)
+    return this.productService.findOne(id)
   }
 
   @Patch(':id')
   update(@Param('id') id: string, @Body() updateProductDto: UpdateProductDto) {
-    return this.productService.update(+id, updateProductDto)
+    return this.productService.update(id, updateProductDto)
   }
 
   @Delete(':id')
   remove(@Param('id') id: string) {
-    return this.productService.remove(+id)
+    return this.productService.remove(id)
   }
 }

--- a/apps/services/api-gateway/src/product/product.service.ts
+++ b/apps/services/api-gateway/src/product/product.service.ts
@@ -1,9 +1,13 @@
-import { CreateProductPayload, ProductResult } from '@dailyshop/shared-types'
+import {
+  CreateProductPayload,
+  ProductEntity,
+  ProductResult,
+  UpdateProductPayload
+} from '@dailyshop/shared-types'
 import { AppLogger } from '@dailyshop/shared-utils'
 import { Inject, Injectable } from '@nestjs/common'
 import { ClientProxy } from '@nestjs/microservices'
 import { firstValueFrom } from 'rxjs'
-import { UpdateProductDto } from './dto/update-product.dto'
 
 @Injectable()
 export class ProductService {
@@ -12,24 +16,34 @@ export class ProductService {
     private readonly logger: AppLogger
   ) {}
 
-  async create(dto: CreateProductPayload) {
+  async create(dto: CreateProductPayload): Promise<ProductResult> {
     this.logger.log(`Creating product with payload: ${JSON.stringify(dto)}`)
-    return firstValueFrom<ProductResult>(this.productClient.send({ cmd: 'product-create' }, dto))
+    return firstValueFrom<ProductResult>(
+      this.productClient.send({ cmd: 'product-create' }, dto)
+    )
   }
 
-  findAll() {
-    return `This action returns all product`
+  async findAll(): Promise<ProductEntity[]> {
+    return firstValueFrom<ProductEntity[]>(
+      this.productClient.send({ cmd: 'product-find-all' }, {})
+    )
   }
 
-  findOne(id: number) {
-    return `This action returns a #${id} product`
+  async findOne(id: string): Promise<ProductEntity | null> {
+    return firstValueFrom<ProductEntity | null>(
+      this.productClient.send({ cmd: 'product-find-one' }, { id })
+    )
   }
 
-  update(id: number, updateProductDto: UpdateProductDto) {
-    return `This action updates a #${id} product`
+  async update(id: string, dto: UpdateProductPayload): Promise<ProductEntity | null> {
+    return firstValueFrom<ProductEntity | null>(
+      this.productClient.send({ cmd: 'product-update' }, { id, data: dto })
+    )
   }
 
-  remove(id: number) {
-    return `This action removes a #${id} product`
+  async remove(id: string): Promise<boolean> {
+    return firstValueFrom<boolean>(
+      this.productClient.send({ cmd: 'product-remove' }, { id })
+    )
   }
 }

--- a/apps/services/api-gateway/src/user/user.service.ts
+++ b/apps/services/api-gateway/src/user/user.service.ts
@@ -11,27 +11,27 @@ export class UserService {
     private readonly logger: AppLogger
   ) {}
 
-  async create(dto: CreateUserPayload) {
+  async create(dto: CreateUserPayload): Promise<UserResult> {
     this.logger.log(`Creating user with payload: ${JSON.stringify(dto)}`)
     return firstValueFrom<UserResult>(this.userClient.send({ cmd: 'user-create' }, dto))
   }
 
-  async findAll() {
+  async findAll(): Promise<UserEntity[]> {
     this.logger.log('Fetching all users')
     return firstValueFrom<UserEntity[]>(this.userClient.send({ cmd: 'user-find-all' }, {}))
   }
 
-  async findOne(id: string) {
+  async findOne(id: string): Promise<UserEntity | null> {
     this.logger.log(`Fetching user ${id}`)
     return firstValueFrom<UserEntity | null>(this.userClient.send({ cmd: 'user-find-one' }, id))
   }
 
-  async update(id: string, dto: UpdateUserPayload) {
+  async update(id: string, dto: UpdateUserPayload): Promise<UserEntity | null> {
     this.logger.log(`Updating user ${id}`)
     return firstValueFrom<UserEntity | null>(this.userClient.send({ cmd: 'user-update' }, { id, data: dto }))
   }
 
-  async remove(id: string) {
+  async remove(id: string): Promise<boolean> {
     this.logger.log(`Removing user ${id}`)
     return firstValueFrom<boolean>(this.userClient.send({ cmd: 'user-remove' }, id))
   }

--- a/apps/services/auth-service/src/auth/auth.service.ts
+++ b/apps/services/auth-service/src/auth/auth.service.ts
@@ -1,11 +1,9 @@
-import { AuthResult, ValidateTokenResult } from '@dailyshop/shared-types'
+import { AuthResult, LoginPayload, RegisterPayload, ValidateTokenResult } from '@dailyshop/shared-types'
 import { AppLogger } from '@dailyshop/shared-utils'
 import { Injectable } from '@nestjs/common'
 import { JwtService } from '@nestjs/jwt'
 import * as bcrypt from 'bcrypt'
 import * as crypto from 'crypto'
-import { LoginDto } from './dto/login.dto'
-import { RegisterDto } from './dto/register.dto'
 import { Auth } from './entities/auth.entity'
 
 @Injectable()
@@ -15,7 +13,7 @@ export class AuthService {
     private readonly logger: AppLogger
   ) {}
 
-  async register(dto: RegisterDto): Promise<AuthResult> {
+  async register(dto: RegisterPayload): Promise<AuthResult> {
     this.logger.log(`Registering user: ${dto.email}`)
     const hashedPassword = await bcrypt.hash(dto.password, 10)
 
@@ -35,7 +33,7 @@ export class AuthService {
     }
   }
 
-  login(dto: LoginDto): { access_token: string } {
+  login(dto: LoginPayload): { access_token: string } {
     this.logger.log(`Login attempt: ${dto.email}`)
     const payload = { sub: 'dummy-user-id', email: dto.email }
     const token = this.jwtService.sign(payload)

--- a/apps/services/product-service/src/product/product.service.ts
+++ b/apps/services/product-service/src/product/product.service.ts
@@ -1,25 +1,39 @@
-import { CreateProductPayload, UpdateProductPayload } from '@dailyshop/shared-types'
+import {
+  CreateProductPayload,
+  ProductEntity,
+  ProductResult,
+  UpdateProductPayload
+} from '@dailyshop/shared-types'
 import { Injectable } from '@nestjs/common'
 
 @Injectable()
 export class ProductService {
-  create(payload: CreateProductPayload) {
-    return 'This action adds a new product'
+  create(payload: CreateProductPayload): ProductResult {
+    const now = new Date()
+    const product: ProductEntity = {
+      id: 'temp-id',
+      name: payload.name,
+      description: payload.description,
+      price: payload.price,
+      createdAt: now,
+      updatedAt: now
+    }
+    return { message: 'Product created', product }
   }
 
-  findAll() {
-    return `This action returns all product`
+  findAll(): ProductEntity[] {
+    return []
   }
 
-  findOne(id: string) {
-    return `This action returns a #${id} product`
+  findOne(id: string): ProductEntity | null {
+    return null
   }
 
-  update(id: string, payload: UpdateProductPayload) {
-    return `This action updates a #${id} product`
+  update(id: string, payload: UpdateProductPayload): ProductEntity | null {
+    return null
   }
 
-  remove(id: string) {
-    return `This action removes a #${id} product`
+  remove(id: string): boolean {
+    return false
   }
 }


### PR DESCRIPTION
## Summary
- switch Auth microservice and gateway services to shared payload interfaces
- use shared payloads in Product gateway service
- type annotate gateway UserService
- add basic product result placeholders

## Testing
- `pnpm test` *(fails: concurrently not found)*

------
https://chatgpt.com/codex/tasks/task_e_68864362cdd8832d82d582b8d2bb118d