### PR TITLE
Fix Docker runtime issues

### DIFF
--- a/apps/services/api-gateway/tsconfig.json
+++ b/apps/services/api-gateway/tsconfig.json
@@ -9,6 +9,7 @@
     "allowSyntheticDefaultImports": true,
     "target": "ES2023",
     "sourceMap": true,
+    "rootDir": "./src",
     "outDir": "./dist",
     "baseUrl": "./",
     "incremental": true,

--- a/apps/services/auth-service/tsconfig.json
+++ b/apps/services/auth-service/tsconfig.json
@@ -9,6 +9,7 @@
     "allowSyntheticDefaultImports": true,
     "target": "ES2023",
     "sourceMap": true,
+    "rootDir": "./src",
     "outDir": "./dist",
     "baseUrl": "./",
     "incremental": true,

--- a/apps/services/product-service/tsconfig.json
+++ b/apps/services/product-service/tsconfig.json
@@ -9,6 +9,7 @@
     "allowSyntheticDefaultImports": true,
     "target": "ES2023",
     "sourceMap": true,
+    "rootDir": "./src",
     "outDir": "./dist",
     "baseUrl": "./",
     "incremental": true,

--- a/apps/services/user-service/tsconfig.json
+++ b/apps/services/user-service/tsconfig.json
@@ -9,6 +9,7 @@
     "allowSyntheticDefaultImports": true,
     "target": "ES2023",
     "sourceMap": true,
+    "rootDir": "./src",
     "outDir": "./dist",
     "baseUrl": "./",
     "incremental": true,

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -19,6 +19,9 @@ FROM node:24.4.1-alpine AS runner
 WORKDIR /app
 ENV NODE_ENV=production
 
+# Install pnpm runtime via corepack
+RUN corepack enable && corepack prepare pnpm@latest --activate
+
 COPY --from=builder /app/apps/web/.next apps/web/.next
 COPY --from=builder /app/apps/web/public apps/web/public
 COPY --from=builder /app/node_modules ./node_modules


### PR DESCRIPTION
## Summary
- install pnpm in the runtime image for the web app
- set `rootDir` for each service so build output goes to `dist`

## Testing
- `pnpm test` *(fails: concurrently not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887c404edac832da8223804e0259e38