### PR TITLE
Add Docker Compose setup

### DIFF
--- a/DOCKER_SETUP.md
+++ b/DOCKER_SETUP.md
@@ -1,1 +1,21 @@
- 
+# Docker Ortami
+
+Bu repodaki servisleri ve Next.js tabanli web uygulamasini Docker ile calistirmak icin `docker-compose.yml` dosyasi eklenmistir. Tum uygulamalar tek Dockerfile kullanarak Turbo ile derlenir.
+
+## Kullanım
+
+1. Tum servislerin ve web uygulamasinin imajlarini olusturmak ve baslatmak icin:
+
+```bash
+docker compose up --build
+```
+
+2. Uygulamalar varsayilan olarak asagidaki portlarda calisir:
+
+- API Gateway: `http://localhost:4000`
+- Auth Service: `http://localhost:4001`
+- User Service: `http://localhost:4002`
+- Product Service: `http://localhost:4003`
+- Web: `http://localhost:3000`
+
+Ihtiyac duyarsaniz `docker-compose.yml` icindeki portlari degistirebilirsiniz.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+# Base image with pnpm and turbo
+FROM node:20-alpine AS base
+WORKDIR /repo
+RUN npm install -g pnpm turbo
+COPY package.json pnpm-lock.yaml turbo.json ./
+COPY apps ./apps
+COPY libs ./libs
+RUN pnpm install --frozen-lockfile
+
+# Build stage for a specific app
+FROM base AS build
+ARG APP
+RUN pnpm turbo build --filter=$APP
+
+# Production runtime
+FROM node:20-alpine AS runner
+WORKDIR /app
+RUN npm install -g pnpm
+ARG APP
+ARG BUILD_DIR=dist
+ARG START_CMD="node dist/main.js"
+COPY --from=build /repo/$APP/$BUILD_DIR ./$BUILD_DIR
+COPY $APP/package.json ./package.json
+COPY pnpm-lock.yaml ./pnpm-lock.yaml
+RUN pnpm install --prod --frozen-lockfile
+CMD sh -c "$START_CMD"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,52 @@
+version: '3.8'
+services:
+  api-gateway:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        APP: apps/services/api-gateway
+        BUILD_DIR: dist
+        START_CMD: node dist/main.js
+    ports:
+      - '4000:4000'
+  auth-service:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        APP: apps/services/auth-service
+        BUILD_DIR: dist
+        START_CMD: node dist/main.js
+    ports:
+      - '4001:4001'
+  user-service:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        APP: apps/services/user-service
+        BUILD_DIR: dist
+        START_CMD: node dist/main.js
+    ports:
+      - '4002:4002'
+  product-service:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        APP: apps/services/product-service
+        BUILD_DIR: dist
+        START_CMD: node dist/main.js
+    ports:
+      - '4003:4003'
+  web:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        APP: apps/web
+        BUILD_DIR: .next
+        START_CMD: next start
+    ports:
+      - '3000:3000'


### PR DESCRIPTION
## Summary
- provide a single Dockerfile using Turbo to build any package
- orchestrate services and the web app with `docker-compose.yml`
- document Docker usage in `DOCKER_SETUP.md`

## Testing
- `pnpm lint` *(fails: unable to download packages)*

------
https://chatgpt.com/codex/tasks/task_e_688c08240930832d87cae92330a4487d